### PR TITLE
Use Dynamic expiry in tests

### DIFF
--- a/test/add-remove-liquidate-burn.test.ts
+++ b/test/add-remove-liquidate-burn.test.ts
@@ -11,8 +11,8 @@ const OptionsFactory = artifacts.require('OptionsFactory');
 const MockCompoundOracle = artifacts.require('MockCompoundOracle');
 const MintableToken = artifacts.require('ERC20Mintable');
 
-import {getUnixTime, addMonths} from 'date-fns';
 const {
+  time,
   BN,
   balance,
   expectEvent,
@@ -56,13 +56,12 @@ contract('OptionsContract', accounts => {
     optionsFactory = await OptionsFactory.deployed();
 
     await optionsFactory.addAsset('DAI', dai.address);
-    // TODO: deploy a mock USDC and get its address
     await optionsFactory.addAsset('USDC', usdc.address);
 
-    const now = Date.now();
-    const expiry = getUnixTime(addMonths(now, 3));
+    // const windowSize = expiry;
+    const now = (await time.latest()).toNumber();
+    const expiry = now + time.duration.days(30).toNumber();
     const windowSize = expiry;
-
     // Create the unexpired options contract
     const optionsContractResult = await optionsFactory.createOptionsContract(
       'ETH',

--- a/test/exercise-add-remove-liquidate-exersice.test.ts
+++ b/test/exercise-add-remove-liquidate-exersice.test.ts
@@ -12,7 +12,7 @@ const MockCompoundOracle = artifacts.require('MockCompoundOracle');
 const MintableToken = artifacts.require('ERC20Mintable');
 
 import Reverter from './utils/reverter';
-import {getUnixTime, addMonths} from 'date-fns';
+
 const {
   BN,
   balance,

--- a/test/exercise-add-remove-liquidate-exersice.test.ts
+++ b/test/exercise-add-remove-liquidate-exersice.test.ts
@@ -45,11 +45,14 @@ contract('OptionsContract', accounts => {
   const vault2Collateral = '10000000';
   const vault2PutsOutstanding = '100000';
 
-  const now = Date.now();
-  const expiry = getUnixTime(addMonths(now, 3));
-  const windowSize = expiry;
+  let expiry: number;
+  let windowSize: number;
 
   before('set up contracts', async () => {
+    const now = (await time.latest()).toNumber();
+    expiry = now + time.duration.days(30).toNumber();
+    windowSize = expiry; // time.duration.days(1).toNumber();
+
     // 1. Deploy mock contracts
     // 1.1 Compound Oracle
     compoundOracle = await MockCompoundOracle.deployed();

--- a/test/liquidate.test.ts
+++ b/test/liquidate.test.ts
@@ -12,10 +12,10 @@ const MockCompoundOracle = artifacts.require('MockCompoundOracle');
 const MintableToken = artifacts.require('ERC20Mintable');
 
 import Reverter from './utils/reverter';
-import {getUnixTime, addMonths} from 'date-fns';
 import {checkVault} from './utils/helper';
 const {
   BN,
+  time,
   balance,
   expectEvent,
   expectRevert
@@ -42,14 +42,13 @@ contract('OptionsContract', accounts => {
   const vault1Collateral = '20000000';
   const vault1PutsOutstanding = '250000';
 
-  // const vault2Collateral = '10000000';
-  // const vault2PutsOutstanding = '100000';
-
-  const now = Date.now();
-  const expiry = getUnixTime(addMonths(now, 3));
-  const windowSize = expiry;
+  let expiry: number;
+  let windowSize: number;
 
   before('set up contracts', async () => {
+    const now = (await time.latest()).toNumber();
+    expiry = now + time.duration.days(30).toNumber();
+    windowSize = expiry;
     // 1. Deploy mock contracts
     // 1.1 Compound Oracle
     compoundOracle = await MockCompoundOracle.deployed();

--- a/test/miltiple-exercise.test.ts
+++ b/test/miltiple-exercise.test.ts
@@ -12,7 +12,6 @@ const MockCompoundOracle = artifacts.require('MockCompoundOracle');
 const MintableToken = artifacts.require('ERC20Mintable');
 
 import Reverter from './utils/reverter';
-import {getUnixTime, addMonths} from 'date-fns';
 
 const {BN, balance, time, expectEvent} = require('@openzeppelin/test-helpers');
 
@@ -38,11 +37,13 @@ contract('OptionsContract', accounts => {
   const vault2Collateral = '10000000';
   const vault2PutsOutstanding = '100000';
 
-  const now = Date.now();
-  const expiry = getUnixTime(addMonths(now, 3));
-  const windowSize = expiry;
+  let expiry: number;
+  let windowSize: number;
 
   before('set up contracts', async () => {
+    const now = (await time.latest()).toNumber();
+    expiry = now + time.duration.days(30).toNumber();
+    windowSize = expiry;
     // 1. Deploy mock contracts
     // 1.1 Compound Oracle
     compoundOracle = await MockCompoundOracle.deployed();

--- a/test/optionsContract.test.ts
+++ b/test/optionsContract.test.ts
@@ -14,7 +14,6 @@ const truffleAssert = require('truffle-assertions');
 
 import Reverter from './utils/reverter';
 
-import {getUnixTime, addMonths} from 'date-fns';
 import {checkVault} from './utils/helper';
 const {time, expectEvent, expectRevert} = require('@openzeppelin/test-helpers');
 
@@ -31,11 +30,13 @@ contract('OptionsContract', accounts => {
   let dai: Erc20MintableInstance;
   let usdc: Erc20MintableInstance;
 
-  const now = Date.now();
-  const expiry = getUnixTime(addMonths(now, 3));
-  const windowSize = expiry;
+  let expiry: number;
+  let windowSize: number;
 
   before('set up contracts', async () => {
+    const now = (await time.latest()).toNumber();
+    expiry = now + time.duration.days(30).toNumber();
+    windowSize = expiry;
     // 1. Deploy mock contracts
     // 1.1 Compound Oracle
     await MockCompoundOracle.deployed();

--- a/test/optionsFactory.test.ts
+++ b/test/optionsFactory.test.ts
@@ -8,7 +8,7 @@ const truffleAssert = require('truffle-assertions');
 
 import {getUnixTime, addMonths, addSeconds, fromUnixTime} from 'date-fns';
 
-const {expectRevert} = require('@openzeppelin/test-helpers');
+const {expectRevert, time} = require('@openzeppelin/test-helpers');
 
 contract('OptionsFactory', accounts => {
   const creatorAddress = accounts[0];
@@ -17,10 +17,13 @@ contract('OptionsFactory', accounts => {
   let optionsFactory: OptionsFactoryInstance;
 
   const now = Date.now();
-  const expiry = getUnixTime(addMonths(now, 3));
-  const windowSize = expiry;
+  let expiry: number;
+  let windowSize: number;
 
   before(async () => {
+    const now = (await time.latest()).toNumber();
+    expiry = now + time.duration.days(30).toNumber();
+    windowSize = expiry;
     optionsFactory = await OptionsFactory.deployed();
     // 1. Deploy our contracts
     // deploys the Options Exhange contract

--- a/test/optionsFactory.test.ts
+++ b/test/optionsFactory.test.ts
@@ -6,7 +6,7 @@ const OptionsFactory = artifacts.require('OptionsFactory');
 const OptionsContract = artifacts.require('OptionsContract');
 const truffleAssert = require('truffle-assertions');
 
-import {getUnixTime, addMonths, addSeconds, fromUnixTime} from 'date-fns';
+import {getUnixTime, addSeconds, fromUnixTime} from 'date-fns';
 
 const {expectRevert, time} = require('@openzeppelin/test-helpers');
 
@@ -16,7 +16,6 @@ contract('OptionsFactory', accounts => {
 
   let optionsFactory: OptionsFactoryInstance;
 
-  const now = Date.now();
   let expiry: number;
   let windowSize: number;
 


### PR DESCRIPTION
Using `Date.now` to create expiry is not accurate, because we increase ganache block timestamps to stimulate expiry in some tests.