### PR TITLE
Fix/unused returns

### DIFF
--- a/contracts/OptionsContract.sol
+++ b/contracts/OptionsContract.sol
@@ -361,7 +361,7 @@ contract OptionsContract is Ownable, ERC20 {
     {
         require(
             collateral.transferFrom(msg.sender, address(this), amt),
-            "Could not transfer in collateral tokens"
+            "OptionsContract: transfer collateral failed."
         );
         require(hasVault(vaultOwner), "Vault does not exist");
 
@@ -805,7 +805,7 @@ contract OptionsContract is Ownable, ERC20 {
                     address(this),
                     amtUnderlyingToPay
                 ),
-                "Could not transfer in tokens"
+                "OptionsContract: Could not transfer in tokens"
             );
         }
         // 4.2 burn oTokens
@@ -997,7 +997,10 @@ contract OptionsContract is Ownable, ERC20 {
         if (isETH(collateral)) {
             _addr.transfer(_amt);
         } else {
-            collateral.transfer(_addr, _amt);
+            require(
+                collateral.transfer(_addr, _amt),
+                "OptionsContract: transfer collateral failed."
+            );
         }
     }
 
@@ -1010,7 +1013,10 @@ contract OptionsContract is Ownable, ERC20 {
         if (isETH(underlying)) {
             _addr.transfer(_amt);
         } else {
-            underlying.transfer(_addr, _amt);
+            require(
+                underlying.transfer(_addr, _amt),
+                "OptionsContract: transfer underlying failed"
+            );
         }
     }
 

--- a/contracts/lib/MockOtokensExchange.sol
+++ b/contracts/lib/MockOtokensExchange.sol
@@ -29,14 +29,20 @@ contract MockOtokensExchange {
 
     function pullToken(address _from, address _token, uint256 _amount) internal {
         if(_token != address(0)) 
-            IERC20(_token).transferFrom(_from, address(this), _amount);
+            require(
+                IERC20(_token).transferFrom(_from, address(this), _amount),
+                "MockOtokenExchange: Pull token failed"
+            );
     }
 
     function pushToken(address payable _to, address _token, uint256 _amount) internal {
         if(_token == address(0)) {
             _to.transfer(_amount);
         } else {
-            IERC20(_token).transferFrom(address(this), _to, _amount);
+            require (
+                IERC20(_token).transfer(_to, _amount),
+                "MockOtokenExchange: Push token failed"
+            );
         }
     }
 

--- a/test/otoken.test.ts
+++ b/test/otoken.test.ts
@@ -12,12 +12,7 @@ const MockOtokensExchange = artifacts.require('MockOtokensExchange');
 const MockCompoundOracle = artifacts.require('MockCompoundOracle');
 const MintableToken = artifacts.require('ERC20Mintable');
 
-const {
-  time,
-  expectEvent,
-  expectRevert,
-  send
-} = require('@openzeppelin/test-helpers');
+const {time, expectRevert, send} = require('@openzeppelin/test-helpers');
 
 const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const MAX_UINT256 =


### PR DESCRIPTION
This fix #159 and similar issues by adding requirement check around `ERC20.transfer`, `ERC20.transferFrom`, `ERC20.approve`, which returns a boolean indicating it's successful or not.


The following code in `oToken.sol` is not fixed,
```javascript
this.approve(address(optionsExchange), amtToCreate);
```

 because we are using the `ERC20` contract provided by OZ, which never return false, will only revert if anything is wrong in the function. That's say, even if we add a requirement statement, we can't test it.