### PR TITLE
Refactor constructor

### DIFF
--- a/contracts/OptionsContract.sol
+++ b/contracts/OptionsContract.sol
@@ -105,19 +105,19 @@ contract OptionsContract is Ownable, ERC20 {
      * @param _strikeExp The precision of the strike price.
      * @param _strike The asset in which the insurance is calculated
      * @param _expiry The time at which the insurance expires
-     * @param _oracleAddress The address of the oracle
      * @param _windowSize UNIX time. Exercise window is from `expiry - _windowSize` to `expiry`.
+     * @param _oracleAddress The address of the oracle
      */
     constructor(
         address _collateral,
         address _underlying,
+        address _strike,
         int32 _oTokenExchangeExp,
         uint256 _strikePrice,
         int32 _strikeExp,
-        address _strike,
         uint256 _expiry,
-        address _oracleAddress,
-        uint256 _windowSize
+        uint256 _windowSize,
+        address _oracleAddress
     ) public {
         require(block.timestamp < _expiry, "Can't deploy an expired contract");
         require(
@@ -143,8 +143,8 @@ contract OptionsContract is Ownable, ERC20 {
         underlying = IERC20(_underlying);
         strike = IERC20(_strike);
 
-        collateralExp = -1 * int32(ERC20Detailed(_collateral).decimals());
-        underlyingExp = -1 * int32(ERC20Detailed(_underlying).decimals());
+        collateralExp = getAssetExp(_collateral);
+        underlyingExp = getAssetExp(_underlying);
         require(
             isWithinExponentRange(collateralExp),
             "collateral exponent not within expected range"
@@ -1048,6 +1048,15 @@ contract OptionsContract is Ownable, ERC20 {
             underlying.transfer(_addr, _amt),
             "OptionsContract: transfer underlying failed"
         );
+    }
+
+    /**
+     * @dev internal function to parse token decimals for constructor
+     * @param _asset the asset address
+     */
+    function getAssetExp(address _asset) internal view returns (int32) {
+        if (_asset == address(0)) return -18;
+        return -1 * int32(ERC20Detailed(_asset).decimals());
     }
 
     /**

--- a/contracts/OptionsContract.sol
+++ b/contracts/OptionsContract.sol
@@ -39,9 +39,6 @@ contract OptionsContract is Ownable, ERC20 {
     // 10 is 0.01 i.e. 1% incentive.
     Number public liquidationIncentive = Number(10, -3);
 
-    // 100 is egs. 0.1 i.e. 10%.
-    Number public transactionFee = Number(0, -3);
-
     /* 500 is 0.5. Max amount that a Vault can be liquidated by i.e.
     max collateral that can be taken in one function call */
     Number public liquidationFactor = Number(500, -3);
@@ -49,7 +46,7 @@ contract OptionsContract is Ownable, ERC20 {
     /* 16 means 1.6. The minimum ratio of a Vault's collateral to insurance promised.
     The ratio is calculated as below:
     vault.collateral / (Vault.oTokensIssued * strikePrice) */
-    Number public minCollateralizationRatio = Number(16, -1);
+    Number public minCollateralizationRatio = Number(10, -1);
 
     // The amount of insurance promised per oToken
     Number public strikePrice;
@@ -201,7 +198,6 @@ contract OptionsContract is Ownable, ERC20 {
     event UpdateParameters(
         uint256 liquidationIncentive,
         uint256 liquidationFactor,
-        uint256 transactionFee,
         uint256 minCollateralizationRatio,
         address owner
     );
@@ -235,13 +231,11 @@ contract OptionsContract is Ownable, ERC20 {
      * @notice Can only be called by owner. Used to update the fees, minCollateralizationRatio, etc
      * @param _liquidationIncentive The incentive paid to liquidator. 10 is 0.01 i.e. 1% incentive.
      * @param _liquidationFactor Max amount that a Vault can be liquidated by. 500 is 0.5.
-     * @param _transactionFee The fees paid to our protocol every time a execution happens. 100 is egs. 0.1 i.e. 10%.
      * @param _minCollateralizationRatio The minimum ratio of a Vault's collateral to insurance promised. 16 means 1.6.
      */
     function updateParameters(
         uint256 _liquidationIncentive,
         uint256 _liquidationFactor,
-        uint256 _transactionFee,
         uint256 _minCollateralizationRatio
     ) external onlyOwner {
         require(
@@ -252,7 +246,6 @@ contract OptionsContract is Ownable, ERC20 {
             _liquidationFactor <= 1000,
             "Can't liquidate more than 100% of the vault"
         );
-        require(_transactionFee <= 100, "Can't have transaction fee > 10%");
         require(
             _minCollateralizationRatio >= 10,
             "Can't have minCollateralizationRatio < 1"
@@ -260,13 +253,11 @@ contract OptionsContract is Ownable, ERC20 {
 
         liquidationIncentive.value = _liquidationIncentive;
         liquidationFactor.value = _liquidationFactor;
-        transactionFee.value = _transactionFee;
         minCollateralizationRatio.value = _minCollateralizationRatio;
 
         emit UpdateParameters(
             _liquidationIncentive,
             _liquidationFactor,
-            _transactionFee,
             _minCollateralizationRatio,
             owner()
         );

--- a/contracts/OptionsContract.sol
+++ b/contracts/OptionsContract.sol
@@ -99,9 +99,7 @@ contract OptionsContract is Ownable, ERC20 {
 
     /**
      * @param _collateral The collateral asset
-     * @param _collExp The precision of the collateral (-18 if ETH)
      * @param _underlying The asset that is being protected
-     * @param _underlyingExp The precision of the underlying asset
      * @param _oTokenExchangeExp The precision of the `amount of underlying` that 1 oToken protects
      * @param _strikePrice The amount of strike asset that will be paid out per oToken
      * @param _strikeExp The precision of the strike price.
@@ -111,14 +109,12 @@ contract OptionsContract is Ownable, ERC20 {
      * @param _windowSize UNIX time. Exercise window is from `expiry - _windowSize` to `expiry`.
      */
     constructor(
-        IERC20 _collateral,
-        int32 _collExp,
-        IERC20 _underlying,
-        int32 _underlyingExp,
+        address _collateral,
+        address _underlying,
         int32 _oTokenExchangeExp,
         uint256 _strikePrice,
         int32 _strikeExp,
-        IERC20 _strike,
+        address _strike,
         uint256 _expiry,
         address _oracleAddress,
         uint256 _windowSize
@@ -128,14 +124,7 @@ contract OptionsContract is Ownable, ERC20 {
             _windowSize <= _expiry,
             "Exercise window can't be longer than the contract's lifespan"
         );
-        require(
-            isWithinExponentRange(_collExp),
-            "collateral exponent not within expected range"
-        );
-        require(
-            isWithinExponentRange(_underlyingExp),
-            "underlying exponent not within expected range"
-        );
+
         require(
             isWithinExponentRange(_strikeExp),
             "strike price exponent not within expected range"
@@ -150,15 +139,24 @@ contract OptionsContract is Ownable, ERC20 {
             "OptionsContract: Can't use ETH as underlying."
         );
 
-        collateral = _collateral;
-        collateralExp = _collExp;
+        collateral = IERC20(_collateral);
+        underlying = IERC20(_underlying);
+        strike = IERC20(_strike);
 
-        underlying = _underlying;
-        underlyingExp = _underlyingExp;
+        collateralExp = -1 * int32(ERC20Detailed(_collateral).decimals());
+        underlyingExp = -1 * int32(ERC20Detailed(_underlying).decimals());
+        require(
+            isWithinExponentRange(collateralExp),
+            "collateral exponent not within expected range"
+        );
+        require(
+            isWithinExponentRange(underlyingExp),
+            "underlying exponent not within expected range"
+        );
+
         oTokenExchangeRate = Number(1, _oTokenExchangeExp);
 
         strikePrice = Number(_strikePrice, _strikeExp);
-        strike = _strike;
 
         expiry = _expiry;
         oracle = OracleInterface(_oracleAddress);

--- a/contracts/OptionsFactory.sol
+++ b/contracts/OptionsFactory.sol
@@ -10,7 +10,8 @@ contract OptionsFactory is Ownable {
     using StringComparator for string;
 
     // keys saved in front-end -- look at the docs if needed
-    mapping(string => IERC20) public tokens;
+    // mapping(string => address) public tokens;
+    mapping(address => bool) public whitelisted;
     address[] public optionsContracts;
 
     // The contract which interfaces with the exchange
@@ -18,11 +19,7 @@ contract OptionsFactory is Ownable {
     address public oracleAddress;
 
     event OptionsContractCreated(address addr);
-    event AssetUpdated(
-        string indexed asset,
-        address indexed oldAddr,
-        address indexed newAddr
-    );
+    event AssetWhiteListed(address indexed asset);
 
     /**
      * @param _optionsExchangeAddr: The contract which interfaces with the exchange
@@ -37,63 +34,55 @@ contract OptionsFactory is Ownable {
 
     /**
      * @notice creates a new Option Contract
-     * @param _collateralType The collateral asset. Eg. "ETH"
-     * @param _collateralExp The number of decimals the collateral asset has
-     * @param _underlyingType The underlying asset. Eg. "DAI"
-     * @param _underlyingExp The precision of the underlying asset. Eg. (-18 if Dai)
+     * @param _collateral The collateral asset. Eg. "ETH"
+     * @param _underlying The underlying asset. Eg. "DAI"
      * @param _oTokenExchangeExp Units of underlying that 1 oToken protects
      * @param _strikePrice The amount of strike asset that will be paid out
      * @param _strikeExp The precision of the strike Price
-     * @param _strikeAsset The asset in which the insurance is calculated
+     * @param _strike The asset in which the insurance is calculated
      * @param _expiry The time at which the insurance expires
      * @param _windowSize UNIX time. Exercise window is from `expiry - _windowSize` to `expiry`.
      */
     function createOptionsContract(
-        string calldata _collateralType,
-        int32 _collateralExp,
-        string calldata _underlyingType,
-        int32 _underlyingExp,
+        address _collateral,
+        address _underlying,
         int32 _oTokenExchangeExp,
         uint256 _strikePrice,
         int32 _strikeExp,
-        string calldata _strikeAsset,
+        address _strike,
         uint256 _expiry,
-        uint256 _windowSize
+        uint256 _windowSize,
+        string calldata _name,
+        string calldata _symbol
     ) external returns (address) {
+        require(whitelisted[_collateral], "Collateral not whitelisted.");
+        require(whitelisted[_underlying], "Underlying not whitelisted.");
+        require(whitelisted[_strike], "Strike not whitelisted.");
+
         require(_expiry > block.timestamp, "Cannot create an expired option");
         require(_windowSize <= _expiry, "Invalid _windowSize");
-        require(
-            supportsAsset(_collateralType),
-            "Collateral type not supported"
-        );
-        require(
-            supportsAsset(_underlyingType),
-            "Underlying type not supported"
-        );
-        require(supportsAsset(_strikeAsset), "Strike asset type not supported");
 
-        oToken optionsContract = new oToken(
-            tokens[_collateralType],
-            _collateralExp,
-            tokens[_underlyingType],
-            _underlyingExp,
+        oToken otoken = new oToken(
+            _collateral,
+            _underlying,
             _oTokenExchangeExp,
             _strikePrice,
             _strikeExp,
-            tokens[_strikeAsset],
+            _strike,
             _expiry,
             optionsExchange,
             oracleAddress,
             _windowSize
         );
 
-        optionsContracts.push(address(optionsContract));
-        emit OptionsContractCreated(address(optionsContract));
+        otoken.setDetails(_name, _symbol);
+
+        optionsContracts.push(address(otoken));
+        emit OptionsContractCreated(address(otoken));
 
         // Set the owner for the options contract.
-        optionsContract.transferOwnership(owner());
-
-        return address(optionsContract);
+        otoken.transferOwnership(owner());
+        return address(otoken);
     }
 
     /**
@@ -105,27 +94,10 @@ contract OptionsFactory is Ownable {
 
     /**
      * @notice The owner of the Factory Contract can update an asset's address, by adding it, changing the address or removing the asset
-     * @param _asset The ticker symbol for the asset
-     * @param _addr The address of the asset
+     * @param _asset The address for the asset
      */
-    function updateAsset(string calldata _asset, address _addr)
-        external
-        onlyOwner
-    {
-        emit AssetUpdated(_asset, address(tokens[_asset]), _addr);
-
-        tokens[_asset] = IERC20(_addr);
-    }
-
-    /**
-     * @notice Check if the Factory contract supports a specific asset
-     * @param _asset The ticker symbol for the asset
-     */
-    function supportsAsset(string memory _asset) public view returns (bool) {
-        if (_asset.compareStrings("ETH")) {
-            return true;
-        }
-
-        return tokens[_asset] != IERC20(0);
+    function whitelistAsset(address _asset) external onlyOwner {
+        emit AssetWhiteListed(_asset);
+        whitelisted[_asset] = true;
     }
 }

--- a/contracts/OptionsFactory.sol
+++ b/contracts/OptionsFactory.sol
@@ -9,8 +9,6 @@ import "./packages/IERC20.sol";
 contract OptionsFactory is Ownable {
     using StringComparator for string;
 
-    // keys saved in front-end -- look at the docs if needed
-    // mapping(string => address) public tokens;
     mapping(address => bool) public whitelisted;
     address[] public optionsContracts;
 
@@ -19,7 +17,7 @@ contract OptionsFactory is Ownable {
     address public oracleAddress;
 
     event OptionsContractCreated(address addr);
-    event AssetWhiteListed(address indexed asset);
+    event AssetWhitelisted(address indexed asset);
 
     /**
      * @param _optionsExchangeAddr: The contract which interfaces with the exchange
@@ -46,10 +44,10 @@ contract OptionsFactory is Ownable {
     function createOptionsContract(
         address _collateral,
         address _underlying,
+        address _strike,
         int32 _oTokenExchangeExp,
         uint256 _strikePrice,
         int32 _strikeExp,
-        address _strike,
         uint256 _expiry,
         uint256 _windowSize,
         string calldata _name,
@@ -65,14 +63,14 @@ contract OptionsFactory is Ownable {
         oToken otoken = new oToken(
             _collateral,
             _underlying,
+            _strike,
             _oTokenExchangeExp,
             _strikePrice,
             _strikeExp,
-            _strike,
             _expiry,
+            _windowSize,
             optionsExchange,
-            oracleAddress,
-            _windowSize
+            oracleAddress
         );
 
         otoken.setDetails(_name, _symbol);
@@ -97,7 +95,7 @@ contract OptionsFactory is Ownable {
      * @param _asset The address for the asset
      */
     function whitelistAsset(address _asset) external onlyOwner {
-        emit AssetWhiteListed(_asset);
         whitelisted[_asset] = true;
+        emit AssetWhitelisted(_asset);
     }
 }

--- a/contracts/oToken.sol
+++ b/contracts/oToken.sol
@@ -27,26 +27,26 @@ contract oToken is OptionsContract {
     constructor(
         address _collateral,
         address _underlying,
+        address _strike,
         int32 _oTokenExchangeExp,
         uint256 _strikePrice,
         int32 _strikeExp,
-        address _strike,
         uint256 _expiry,
+        uint256 _windowSize,
         OptionsExchange _optionsExchange,
-        address _oracleAddress,
-        uint256 _windowSize
+        address _oracleAddress
     )
         public
         OptionsContract(
             _collateral,
             _underlying,
+            _strike,
             _oTokenExchangeExp,
             _strikePrice,
             _strikeExp,
-            _strike,
             _expiry,
-            _oracleAddress,
-            _windowSize
+            _windowSize,
+            _oracleAddress
         )
     {
         optionsExchange = _optionsExchange;

--- a/contracts/oToken.sol
+++ b/contracts/oToken.sol
@@ -14,9 +14,7 @@ contract oToken is OptionsContract {
 
     /**
      * @param _collateral The collateral asset
-     * @param _collExp The precision of the collateral (-18 if ETH)
      * @param _underlying The asset that is being protected
-     * @param _underlyingExp The precision of the underlying asset
      * @param _oTokenExchangeExp The precision of the `amount of underlying` that 1 oToken protects
      * @param _strikePrice The amount of strike asset that will be paid out
      * @param _strikeExp The precision of the strike asset (-18 if ETH)
@@ -27,14 +25,12 @@ contract oToken is OptionsContract {
      * @param _windowSize UNIX time. Exercise window is from `expiry - _windowSize` to `expiry`.
      */
     constructor(
-        IERC20 _collateral,
-        int32 _collExp,
-        IERC20 _underlying,
-        int32 _underlyingExp,
+        address _collateral,
+        address _underlying,
         int32 _oTokenExchangeExp,
         uint256 _strikePrice,
         int32 _strikeExp,
-        IERC20 _strike,
+        address _strike,
         uint256 _expiry,
         OptionsExchange _optionsExchange,
         address _oracleAddress,
@@ -43,9 +39,7 @@ contract oToken is OptionsContract {
         public
         OptionsContract(
             _collateral,
-            _collExp,
             _underlying,
-            _underlyingExp,
             _oTokenExchangeExp,
             _strikePrice,
             _strikeExp,

--- a/test/add-remove-liquidate-burn.test.ts
+++ b/test/add-remove-liquidate-burn.test.ts
@@ -82,6 +82,10 @@ contract('OptionsContract', accounts => {
     const optionsContractAddr = optionsContractResult.logs[1].args[0];
     optionsContracts.push(await OptionsContract.at(optionsContractAddr));
 
+    await optionsContracts[0].updateParameters(10, 500, 16, {
+      from: creatorAddress
+    });
+
     // Open vault1, add Collateral and Mint oTokens
     await optionsContracts[0].openVault({
       from: firstVaultOwnerAddress

--- a/test/add-remove-liquidate-burn.test.ts
+++ b/test/add-remove-liquidate-burn.test.ts
@@ -1,15 +1,16 @@
 import {expect} from 'chai';
 import {
-  Erc20MintableInstance,
+  MockErc20Instance,
   MockOracleInstance,
   OptionsContractInstance,
   OptionsFactoryInstance
 } from '../build/types/truffle-types';
+import {ZERO_ADDRESS} from './utils/helper';
 
 const OptionsContract = artifacts.require('OptionsContract');
 const OptionsFactory = artifacts.require('OptionsFactory');
 const MockOracle = artifacts.require('MockOracle');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 
 const {
   time,
@@ -29,8 +30,8 @@ contract('OptionsContract', accounts => {
   const optionsContracts: OptionsContractInstance[] = [];
   let optionsFactory: OptionsFactoryInstance;
   let compoundOracle: MockOracleInstance;
-  let dai: Erc20MintableInstance;
-  let usdc: Erc20MintableInstance;
+  let dai: MockErc20Instance;
+  let usdc: MockErc20Instance;
 
   const vault1Collateral = '20000000';
   const vault1PutsOutstanding = '250000';
@@ -45,18 +46,19 @@ contract('OptionsContract', accounts => {
     // 1.2 Uniswap Factory
 
     // 1.3 Mock Dai contract
-    dai = await MintableToken.new();
+    dai = await MockERC20.new('DAI', 'DAI', 18);
     await dai.mint(creatorAddress, '10000000');
     await dai.mint(tokenHolder, '100000', {from: creatorAddress});
     // 1.4 Mock Dai contract
-    usdc = await MintableToken.new();
+    usdc = await MockERC20.new('USDC', 'USDC', 6);
     await usdc.mint(creatorAddress, '10000000');
 
     // Deploy the Options Factory contract and add assets to it
     optionsFactory = await OptionsFactory.deployed();
 
-    await optionsFactory.updateAsset('DAI', dai.address);
-    await optionsFactory.updateAsset('USDC', usdc.address);
+    await optionsFactory.whitelistAsset(ZERO_ADDRESS);
+    await optionsFactory.whitelistAsset(dai.address);
+    await optionsFactory.whitelistAsset(usdc.address);
 
     // const windowSize = expiry;
     const now = (await time.latest()).toNumber();
@@ -64,16 +66,16 @@ contract('OptionsContract', accounts => {
     const windowSize = expiry;
     // Create the unexpired options contract
     const optionsContractResult = await optionsFactory.createOptionsContract(
-      'ETH',
-      -'18',
-      'DAI',
-      -'18',
+      ZERO_ADDRESS,
+      dai.address,
+      usdc.address,
       -'14',
       '9',
       -'15',
-      'USDC',
       expiry,
       windowSize,
+      'Opyn DAI:USDC option',
+      'oDAI',
       {from: creatorAddress}
     );
 

--- a/test/exercise-add-remove-liquidate-exersice.test.ts
+++ b/test/exercise-add-remove-liquidate-exersice.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {
-  Erc20MintableInstance,
+  MockErc20Instance,
   MockOracleInstance,
   OptionsContractInstance,
   OptionsFactoryInstance
@@ -9,9 +9,10 @@ import {
 const OptionsContract = artifacts.require('OptionsContract');
 const OptionsFactory = artifacts.require('OptionsFactory');
 const MockOracle = artifacts.require('MockOracle');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 
 import Reverter from './utils/reverter';
+import {ZERO_ADDRESS} from './utils/helper';
 
 const {
   BN,
@@ -36,8 +37,8 @@ contract('OptionsContract', accounts => {
   const optionsContracts: OptionsContractInstance[] = [];
   let optionsFactory: OptionsFactoryInstance;
   let compoundOracle: MockOracleInstance;
-  let dai: Erc20MintableInstance;
-  let usdc: Erc20MintableInstance;
+  let dai: MockErc20Instance;
+  let usdc: MockErc20Instance;
 
   const vault1Collateral = '20000000';
   const vault1PutsOutstanding = '250000';
@@ -58,13 +59,13 @@ contract('OptionsContract', accounts => {
     compoundOracle = await MockOracle.deployed();
 
     // 1.2 Mock Dai contract
-    dai = await MintableToken.new();
+    dai = await MockERC20.new('Dai', 'Dai', 18);
     await dai.mint(creatorAddress, '10000000');
     await dai.mint(firstExerciser, '100000', {from: creatorAddress});
     await dai.mint(secondExerciser, '100000', {from: creatorAddress});
 
     // 1.3 Mock Dai contract
-    usdc = await MintableToken.new();
+    usdc = await MockERC20.new('USDC', 'USDC', 6);
     await usdc.mint(creatorAddress, '10000000');
 
     // 2. Deploy our contracts
@@ -72,22 +73,22 @@ contract('OptionsContract', accounts => {
     // Deploy the Options Factory contract and add assets to it
     optionsFactory = await OptionsFactory.deployed();
 
-    await optionsFactory.updateAsset('DAI', dai.address);
-    // TODO: deploy a mock USDC and get its address
-    await optionsFactory.updateAsset('USDC', usdc.address);
+    await optionsFactory.whitelistAsset(ZERO_ADDRESS);
+    await optionsFactory.whitelistAsset(dai.address);
+    await optionsFactory.whitelistAsset(usdc.address);
 
     // Create the unexpired options contract
     const optionsContractResult = await optionsFactory.createOptionsContract(
-      'ETH',
-      -'18',
-      'DAI',
-      -'18',
+      ZERO_ADDRESS,
+      dai.address,
+      usdc.address,
       -'14',
       '9',
       -'15',
-      'USDC',
       expiry,
       windowSize,
+      'Opyn Dai:USDC Option',
+      'oDAI',
       {from: creatorAddress}
     );
 

--- a/test/exercise-add-remove-liquidate-exersice.test.ts
+++ b/test/exercise-add-remove-liquidate-exersice.test.ts
@@ -95,6 +95,10 @@ contract('OptionsContract', accounts => {
     const optionsContractAddr = optionsContractResult.logs[1].args[0];
     optionsContracts.push(await OptionsContract.at(optionsContractAddr));
 
+    await optionsContracts[0].updateParameters(10, 500, 16, {
+      from: creatorAddress
+    });
+
     // Open vault1, add Collateral and Mint oTokens
     await optionsContracts[0].openVault({
       from: firstVaultOwnerAddress
@@ -577,7 +581,7 @@ contract('OptionsContract', accounts => {
 
     it('only owner should be able to update parameters', async () => {
       await expectRevert(
-        optionsContracts[0].updateParameters(0, 0, 0, 0, {
+        optionsContracts[0].updateParameters(0, 0, 0, {
           from: firstVaultOwnerAddress
         }),
         'Ownable: caller is not the owner.'
@@ -587,7 +591,6 @@ contract('OptionsContract', accounts => {
     it('owner should be able to update parameters', async () => {
       const liquidationIncentive = 20;
       const liquidationFactor = 1000;
-      const transactionFee = 10;
       const collateralizationRatio = 20;
 
       let currentCollateralizationRatio = await optionsContracts[0].minCollateralizationRatio();
@@ -596,7 +599,6 @@ contract('OptionsContract', accounts => {
       await optionsContracts[0].updateParameters(
         liquidationIncentive,
         liquidationFactor,
-        transactionFee,
         collateralizationRatio,
         {from: creatorAddress}
       );

--- a/test/exercise-erc20-collateral.test.ts
+++ b/test/exercise-erc20-collateral.test.ts
@@ -70,7 +70,7 @@ contract(
       otoken = await oToken.at(optionsContractAddr);
       // change collateral ratio to 1
 
-      await otoken.updateParameters('100', '500', 0, 10, {
+      await otoken.updateParameters('100', '500', 10, {
         from: creatorAddress
       });
     });

--- a/test/exercise-eth-collateral.test.ts
+++ b/test/exercise-eth-collateral.test.ts
@@ -1,14 +1,15 @@
 import {expect} from 'chai';
 import {
-  Erc20MintableInstance,
+  MockErc20Instance,
   OTokenInstance,
   OptionsFactoryInstance
 } from '../build/types/truffle-types';
 import BN = require('bn.js');
+import {ZERO_ADDRESS} from './utils/helper';
 const oToken = artifacts.require('oToken');
 const OptionsFactory = artifacts.require('OptionsFactory');
 const MockOracle = artifacts.require('MockOracle');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 
 const {
   time,
@@ -23,7 +24,7 @@ contract(
   ([creatorAddress, owner1, owner2, exerciser, nonOwnerAddress]) => {
     let otoken: OTokenInstance;
     let optionsFactory: OptionsFactoryInstance;
-    let usdc: Erc20MintableInstance;
+    let usdc: MockErc20Instance;
     let expiry: number;
 
     let mintAmount: BN;
@@ -38,35 +39,33 @@ contract(
       await MockOracle.deployed();
 
       // 1.2 Mock usdc contract
-      usdc = await MintableToken.new();
+      usdc = await MockERC20.new('USDC', 'USDC', 6);
 
       // 2. Deploy our contracts
       // Deploy the Options Factory contract and add assets to it
       optionsFactory = await OptionsFactory.deployed();
 
-      await optionsFactory.updateAsset('USDC', usdc.address);
+      await optionsFactory.whitelistAsset(usdc.address);
+      await optionsFactory.whitelistAsset(ZERO_ADDRESS);
 
       // Create the unexpired options contract
       const optionsContractResult = await optionsFactory.createOptionsContract(
-        'ETH',
-        -18,
-        'USDC',
-        -6,
+        ZERO_ADDRESS,
+        usdc.address,
+        ZERO_ADDRESS,
         -6,
         4, // strike price
         -9, // strike price exp
-        'ETH',
         expiry,
         expiry,
+        'Opyn USDC:ETH',
+        'oUSDC',
         {from: creatorAddress}
       );
 
       const optionsContractAddr = optionsContractResult.logs[1].args[0];
       otoken = await oToken.at(optionsContractAddr);
       // change collateral ratio to 1
-      await otoken.setDetails('Opyn USDC:ETH', 'oUSDC', {
-        from: creatorAddress
-      });
       await otoken.updateParameters('100', '500', 0, 10, {
         from: creatorAddress
       });

--- a/test/exercise-eth-collateral.test.ts
+++ b/test/exercise-eth-collateral.test.ts
@@ -66,7 +66,7 @@ contract(
       const optionsContractAddr = optionsContractResult.logs[1].args[0];
       otoken = await oToken.at(optionsContractAddr);
       // change collateral ratio to 1
-      await otoken.updateParameters('100', '500', 0, 10, {
+      await otoken.updateParameters('100', '500', 10, {
         from: creatorAddress
       });
 

--- a/test/miltiple-exercise.test.ts
+++ b/test/miltiple-exercise.test.ts
@@ -86,6 +86,10 @@ contract('OptionsContract', accounts => {
     const optionsContractAddr = optionsContractResult.logs[1].args[0];
     optionsContracts.push(await OptionsContract.at(optionsContractAddr));
 
+    await optionsContracts[0].updateParameters(10, 500, 16, {
+      from: creatorAddress
+    });
+
     // Open vault1, add Collateral and Mint oTokens
     await optionsContracts[0].openVault({
       from: firstVaultOwnerAddress

--- a/test/miltiple-exercise.test.ts
+++ b/test/miltiple-exercise.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {
-  Erc20MintableInstance,
+  MockErc20Instance,
   MockOracleInstance,
   OptionsContractInstance,
   OptionsFactoryInstance
@@ -9,8 +9,9 @@ import {
 const OptionsContract = artifacts.require('OptionsContract');
 const OptionsFactory = artifacts.require('OptionsFactory');
 const MockOracle = artifacts.require('MockOracle');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 
+import {ZERO_ADDRESS} from './utils/helper';
 import Reverter from './utils/reverter';
 
 const {BN, balance, time, expectEvent} = require('@openzeppelin/test-helpers');
@@ -28,8 +29,8 @@ contract('OptionsContract', accounts => {
   const optionsContracts: OptionsContractInstance[] = [];
   let optionsFactory: OptionsFactoryInstance;
   let compoundOracle: MockOracleInstance;
-  let dai: Erc20MintableInstance;
-  let usdc: Erc20MintableInstance;
+  let dai: MockErc20Instance;
+  let usdc: MockErc20Instance;
 
   const vault1Collateral = '20000000';
   const vault1PutsOutstanding = '250000';
@@ -49,35 +50,36 @@ contract('OptionsContract', accounts => {
     compoundOracle = await MockOracle.deployed();
 
     // 1.2 Mock Dai contract
-    dai = await MintableToken.new();
+    dai = await MockERC20.new('DAI', 'DAI', 18);
     await dai.mint(creatorAddress, '10000000');
     await dai.mint(firstExerciser, '100000', {from: creatorAddress});
     await dai.mint(secondExerciser, '100000', {from: creatorAddress});
 
     // 1.3 Mock Dai contract
-    usdc = await MintableToken.new();
+    usdc = await MockERC20.new('USDC', 'USDC', 6);
     await usdc.mint(creatorAddress, '10000000');
 
     // 2. Deploy our contracts
     // Deploy the Options Factory contract and add assets to it
     optionsFactory = await OptionsFactory.deployed();
 
-    await optionsFactory.updateAsset('DAI', dai.address);
+    await optionsFactory.whitelistAsset(ZERO_ADDRESS);
+    await optionsFactory.whitelistAsset(dai.address);
     // TODO: deploy a mock USDC and get its address
-    await optionsFactory.updateAsset('USDC', usdc.address);
+    await optionsFactory.whitelistAsset(usdc.address);
 
     // Create the unexpired options contract
     const optionsContractResult = await optionsFactory.createOptionsContract(
-      'ETH',
-      -'18',
-      'DAI',
-      -'18',
+      ZERO_ADDRESS,
+      dai.address,
+      usdc.address,
       -'14',
       '9',
       -'15',
-      'USDC',
       expiry,
       windowSize,
+      'Opyn DAI:USDC',
+      'oDAI',
       {from: creatorAddress}
     );
 

--- a/test/optionsContract.test.ts
+++ b/test/optionsContract.test.ts
@@ -88,6 +88,10 @@ contract('OptionsContract', accounts => {
     let optionsContractAddr = optionsContractResult.logs[1].args[0];
     optionsContracts.push(await OptionsContract.at(optionsContractAddr));
 
+    await optionsContracts[0].updateParameters(10, 500, 16, {
+      from: creatorAddress
+    });
+
     optionsContractResult = await optionsFactory.createOptionsContract(
       usdc.address,
       dai.address,
@@ -107,6 +111,10 @@ contract('OptionsContract', accounts => {
       optionsContractAddr
     );
     optionsContracts.push(ERC20collateralOptContract);
+
+    await optionsContracts[1].updateParameters(10, 500, 16, {
+      from: creatorAddress
+    });
 
     await reverter.snapshot();
   });
@@ -287,47 +295,39 @@ contract('OptionsContract', accounts => {
 
     it('should revert when calling from other address', async () => {
       await expectRevert(
-        option.updateParameters(100, 500, 0, 10, {from: random}),
+        option.updateParameters(100, 500, 10, {from: random}),
         'Ownable: caller is not the owner'
       );
     });
 
     it('should revert when trying to set liquidation incentive > 200%', async () => {
       await expectRevert(
-        option.updateParameters(201, 500, 0, 10), //
+        option.updateParameters(201, 500, 10), //
         "Can't have >20% liquidation incentive"
-      );
-    });
-
-    it('should revert when trying to set transaction fee > 10%', async () => {
-      await expectRevert(
-        option.updateParameters(100, 500, 101, 10), //
-        "Can't have transaction fee > 10%"
       );
     });
 
     it('should revert when trying to set liquidation factor > 100%', async () => {
       await expectRevert(
-        option.updateParameters(100, 1001, 0, 10), //
+        option.updateParameters(100, 1001, 10), //
         "Can't liquidate more than 100% of the vault"
       );
     });
 
     it('should revert when trying to set collateral ratio < 1', async () => {
       await expectRevert(
-        option.updateParameters(100, 500, 0, 9), //
+        option.updateParameters(100, 500, 9), //
         "Can't have minCollateralizationRatio < 1"
       );
     });
 
     it('should emit UpdateParameters event ', async () => {
       expectEvent(
-        await option.updateParameters(200, 500, 0, 10), //
+        await option.updateParameters(200, 500, 10), //
         'UpdateParameters',
         {
           liquidationIncentive: '200',
           liquidationFactor: '500',
-          transactionFee: '0',
           minCollateralizationRatio: '10'
         }
       );

--- a/test/otoken.test.ts
+++ b/test/otoken.test.ts
@@ -1,5 +1,5 @@
 import {
-  Erc20MintableInstance,
+  MockErc20Instance,
   MockOracleInstance,
   OTokenInstance,
   MockOtokensExchangeInstance
@@ -10,7 +10,7 @@ import BN = require('bn.js');
 const OToken = artifacts.require('oToken');
 const MockOtokensExchange = artifacts.require('MockOtokensExchange');
 const MockOracle = artifacts.require('MockOracle');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 
 const {time, expectRevert, send} = require('@openzeppelin/test-helpers');
 
@@ -29,8 +29,8 @@ contract('OToken', accounts => {
 
   let exchange: MockOtokensExchangeInstance;
   let oracle: MockOracleInstance;
-  let dai: Erc20MintableInstance;
-  let usdc: Erc20MintableInstance;
+  let dai: MockErc20Instance;
+  let usdc: MockErc20Instance;
 
   let otoken1: OTokenInstance; // erc20 collateral options
   let otoken2: OTokenInstance; // eth collateral options
@@ -47,13 +47,13 @@ contract('OToken', accounts => {
     oracle = await MockOracle.new();
 
     // 1.2 Mock Dai contract
-    dai = await MintableToken.new();
+    dai = await MockERC20.new('DAI', 'DAI', 18);
     await dai.mint(creatorAddress, '10000000');
 
     exchange = await MockOtokensExchange.new();
 
     // 1.3 Mock USDC contract
-    usdc = await MintableToken.new();
+    usdc = await MockERC20.new('USDC', 'USDC', 6);
     await usdc.mint(creatorAddress, '10000000000');
     await usdc.mint(firstOwner, '10000000000');
     await usdc.mint(secondOwner, '10000000000');
@@ -64,34 +64,30 @@ contract('OToken', accounts => {
     it('should create an ERC20 collateral option', async () => {
       otoken1 = await OToken.new(
         usdc.address,
-        -'18',
         dai.address,
-        -'18',
+        usdc.address,
         -'17',
         '90',
         -'18',
-        usdc.address,
         expiry,
+        windowSize,
         exchange.address,
-        oracle.address,
-        windowSize
+        oracle.address
       );
     });
 
     it('should create an ETH collateral option', async () => {
       otoken2 = await OToken.new(
         ZERO_ADDRESS,
-        -'18',
         dai.address,
-        -'18',
+        usdc.address,
         -'17',
         '90',
         -'18',
-        usdc.address,
         expiry,
+        windowSize,
         exchange.address,
-        oracle.address,
-        windowSize
+        oracle.address
       );
     });
   });

--- a/test/sell-and-buy.test.ts
+++ b/test/sell-and-buy.test.ts
@@ -1,6 +1,6 @@
 /*import {expect} from 'chai';
 import {
-  Erc20MintableInstance,
+  MockErc20Instance,
   OTokenInstance,
   OptionsFactoryInstance,
   OptionsExchangeInstance,
@@ -13,7 +13,7 @@ import {
 import {Address} from 'cluster';
 
 const OptionsFactory = artifacts.require('OptionsFactory');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 const UniswapFactory = artifacts.require('UniswapFactoryInterface');
 const UniswapExchange = artifacts.require('UniswapExchangeInterface');
 const OptionsExchange = artifacts.require('OptionsExchange.sol');
@@ -59,8 +59,8 @@ contract('OptionsContract', accounts => {
 
   const optionsContracts: OTokenInstance[] = [];
   let optionsFactory: OptionsFactoryInstance;
-  let dai: Erc20MintableInstance;
-  let usdc: Erc20MintableInstance;
+  let dai: MockErc20Instance;
+  let usdc: MockErc20Instance;
   let uniswapFactory: UniswapFactoryInterfaceInstance;
   let optionsExchange: OptionsExchangeInstance;
   let oracle: OracleInstance;
@@ -120,9 +120,9 @@ contract('OptionsContract', accounts => {
     if (!contractsDeployed) {
       oracle = await Oracle.deployed();
       // 1.2 Mock Dai contract
-      dai = await MintableToken.at(daiAddress);
+      dai = await MockERC20.at(daiAddress);
       // 1.3 USDC contract
-      usdc = await MintableToken.at(usdcAddress);
+      usdc = await MockERC20.at(usdcAddress);
 
       // 2. Deploy our contracts
       // Deploy the Options Exchange
@@ -434,7 +434,7 @@ contract('OptionsContract', accounts => {
 
     xit('should be able to buy oTokens with ERC20s', async () => {
       const paymentTokenAddr = '0x2448eE2641d78CC42D7AD76498917359D961A783';
-      const paymentToken = await MintableToken.at(paymentTokenAddr);
+      const paymentToken = await MockERC20.at(paymentTokenAddr);
       // set to optionsCotnracs[0].address
       const oTokenAddress = optionsContractAddresses[0];
       await paymentToken.approve(

--- a/test/series/bal-put.test.ts
+++ b/test/series/bal-put.test.ts
@@ -87,7 +87,7 @@ contract('OptionsContract: BAL put', accounts => {
     });
 
     it('should update parameters', async () => {
-      await oToken.updateParameters(0, 500, 0, 10, {
+      await oToken.updateParameters(0, 500, 10, {
         from: creatorAddress
       });
     });

--- a/test/series/bal-put.test.ts
+++ b/test/series/bal-put.test.ts
@@ -1,7 +1,7 @@
 import {
   OptionsFactoryInstance,
   OTokenInstance,
-  Erc20MintableInstance
+  MockErc20Instance
 } from '../../build/types/truffle-types';
 
 import BigNumber from 'bignumber.js';
@@ -9,7 +9,7 @@ const {time, expectEvent} = require('@openzeppelin/test-helpers');
 
 const OTokenContract = artifacts.require('oToken');
 const OptionsFactory = artifacts.require('OptionsFactory');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 
 import Reverter from '../utils/reverter';
 
@@ -22,8 +22,8 @@ contract('OptionsContract: BAL put', accounts => {
 
   let optionsFactory: OptionsFactoryInstance;
   let oToken: OTokenInstance;
-  let bal: Erc20MintableInstance;
-  let usdc: Erc20MintableInstance;
+  let bal: MockErc20Instance;
+  let usdc: MockErc20Instance;
 
   const _name = 'Opyn BAL Put $7 08/28/20';
   const _symbol = 'oBALp $7';
@@ -44,32 +44,33 @@ contract('OptionsContract: BAL put', accounts => {
     // oracle = MockOracle.at()
 
     // 1.2 Mock BAL contract
-    bal = await MintableToken.new();
+    bal = await MockERC20.new('bal', 'bal', 18);
     await bal.mint(creatorAddress, new BigNumber(1000).times(balDigits)); // 1000 bal
     await bal.mint(firstOwner, new BigNumber(1000).times(balDigits));
     await bal.mint(tokenHolder, new BigNumber(1000).times(balDigits));
 
     // 1.3 Mock USDT contract
-    usdc = await MintableToken.new();
+    usdc = await MockERC20.new('USDC', 'USDC', 6);
     await usdc.mint(creatorAddress, new BigNumber(7000).times(usdcDigits)); // 1000 USDC
     await usdc.mint(firstOwner, new BigNumber(7000).times(usdcDigits));
 
     // 2. Deploy the Options Factory contract and add assets to it
     optionsFactory = await OptionsFactory.deployed();
 
-    await optionsFactory.updateAsset('BAL', bal.address);
-    await optionsFactory.updateAsset('USDC', usdc.address);
+    await optionsFactory.whitelistAsset(bal.address);
+    await optionsFactory.whitelistAsset(usdc.address);
+
     const optionsContractResult = await optionsFactory.createOptionsContract(
-      'USDC',
-      -6,
-      'BAL',
-      -18,
+      usdc.address,
+      bal.address,
+      usdc.address,
       -_tokenDecimals,
       7,
       -7,
-      'USDC',
       expiry,
       windowSize,
+      _name,
+      _symbol,
       {from: creatorAddress}
     );
 
@@ -81,10 +82,6 @@ contract('OptionsContract: BAL put', accounts => {
 
   describe('New option parameter test', () => {
     it('should have basic setting', async () => {
-      await oToken.setDetails(_name, _symbol, {
-        from: creatorAddress
-      });
-
       assert.equal(await oToken.name(), String(_name), 'set name error');
       assert.equal(await oToken.symbol(), String(_symbol), 'set symbol error');
     });

--- a/test/series/comp-put.test.ts
+++ b/test/series/comp-put.test.ts
@@ -82,7 +82,7 @@ contract('OptionsContract: COMP put', accounts => {
     });
 
     it('should update parameters', async () => {
-      await oComp.updateParameters('100', '500', 0, 10, {from: creatorAddress});
+      await oComp.updateParameters('100', '500', 10, {from: creatorAddress});
     });
 
     it('should open empty vault', async () => {

--- a/test/series/eth-call.test.ts
+++ b/test/series/eth-call.test.ts
@@ -30,20 +30,18 @@ contract(
 
     const _name = 'test call option $280';
     const _symbol = 'test oETH $280';
-    const _collateralType = 'ETH';
+
     const _collateralExp = -18;
-    const _underlyingType = 'USDC';
+
     const _underlyingExp = -6;
     const _oTokenExchangeExp = -6;
     const _strikePrice = 3571428;
     const _strikeExp = -15;
-    const _strikeAsset = 'ETH';
 
     let _expiry: number;
     let _windowSize: number;
     const _liquidationIncentiveValue = 0;
     const _liquidationFactorValue = 0;
-    const _transactionFeeValue = 0;
     const _minCollateralizationRatioValue = 10;
     const _minCollateralizationRatioExp = -1;
 
@@ -97,7 +95,6 @@ contract(
       await optionContract.updateParameters(
         _liquidationIncentiveValue,
         _liquidationFactorValue,
-        _transactionFeeValue,
         _minCollateralizationRatioValue,
         {from: opynDeployer}
       );

--- a/test/series/eth-cusdc-put.test.ts
+++ b/test/series/eth-cusdc-put.test.ts
@@ -3,7 +3,6 @@ import {
   MockErc20Instance,
   MockCtokenInstance,
   MockCompoundOracleInstance,
-  MockOracleInstance,
   MockOtokensExchangeInstance,
   OracleInstance
 } from '../../build/types/truffle-types';
@@ -12,7 +11,6 @@ import BigNumber from 'bignumber.js';
 const {time, expectRevert, expectEvent} = require('@openzeppelin/test-helpers');
 
 const OTokenContract = artifacts.require('oToken');
-const OptionsContract = artifacts.require('OptionsContract');
 
 const Oracle = artifacts.require('Oracle');
 const MockCompoundOracle = artifacts.require('MockCompoundOracle');
@@ -88,17 +86,15 @@ contract('OptionsContract: ETH:cUSDC Put', accounts => {
     // Create the unexpired options contract
     oETH = await OTokenContract.new(
       cusdc.address,
-      -8,
       weth.address,
-      -18,
+      usdc.address,
       -7,
       25,
       -6,
-      usdc.address,
       expiry,
+      windowSize,
       exchange.address,
       oracle.address,
-      windowSize,
       {from: creatorAddress}
     );
   });
@@ -111,10 +107,6 @@ contract('OptionsContract: ETH:cUSDC Put', accounts => {
 
       assert.equal(await oETH.name(), String(_name), 'set name error');
       assert.equal(await oETH.symbol(), String(_symbol), 'set symbol error');
-    });
-
-    it('should update parameters', async () => {
-      await oETH.updateParameters('100', '500', 0, 10, {from: creatorAddress});
     });
 
     it('should open empty vault', async () => {

--- a/test/series/eth-put.test.ts
+++ b/test/series/eth-put.test.ts
@@ -83,7 +83,7 @@ contract('OptionsContract: ETH put', accounts => {
     });
 
     it('should update parameters', async () => {
-      await oETH.updateParameters('100', '500', 0, 10, {from: creatorAddress});
+      await oETH.updateParameters('100', '500', 10, {from: creatorAddress});
     });
 
     it('should open empty vault', async () => {

--- a/test/series/eth-put.test.ts
+++ b/test/series/eth-put.test.ts
@@ -1,7 +1,7 @@
 import {
   OptionsFactoryInstance,
   OTokenInstance,
-  Erc20MintableInstance
+  MockErc20Instance
 } from '../../build/types/truffle-types';
 
 import BigNumber from 'bignumber.js';
@@ -9,7 +9,7 @@ const {time, expectRevert, expectEvent} = require('@openzeppelin/test-helpers');
 
 const OTokenContract = artifacts.require('oToken');
 const OptionsFactory = artifacts.require('OptionsFactory');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 import Reverter from '../utils/reverter';
 
 contract('OptionsContract: ETH put', accounts => {
@@ -22,9 +22,9 @@ contract('OptionsContract: ETH put', accounts => {
   let optionsFactory: OptionsFactoryInstance;
   let oETH: OTokenInstance;
   // let oracle: MockOracleInstance;
-  // let comp: Erc20MintableInstance;
-  let usdc: Erc20MintableInstance;
-  let weth: Erc20MintableInstance;
+  // let comp: MockErc20Instance;
+  let usdc: MockErc20Instance;
+  let weth: MockErc20Instance;
 
   const usdcAmount = '1000000000'; // 1000 USDC
 
@@ -40,29 +40,29 @@ contract('OptionsContract: ETH put', accounts => {
     // 1.2 Mock Comp contract
 
     // 1.3 Mock USDC contract
-    usdc = await MintableToken.new();
-    weth = await MintableToken.new();
+    usdc = await MockERC20.new('USDC', 'USDC', 6);
+    weth = await MockERC20.new('WETH', 'WETH', 18);
     await usdc.mint(creatorAddress, usdcAmount);
     await usdc.mint(firstOwner, usdcAmount);
 
     // 2. Deploy the Options Factory contract and add assets to it
     optionsFactory = await OptionsFactory.deployed();
 
-    await optionsFactory.updateAsset('USDC', usdc.address);
-    await optionsFactory.updateAsset('WETH', weth.address);
+    await optionsFactory.whitelistAsset(usdc.address);
+    await optionsFactory.whitelistAsset(weth.address);
 
     // Create the unexpired options contract
     const optionsContractResult = await optionsFactory.createOptionsContract(
-      'USDC',
-      -6,
-      'WETH',
-      -18,
+      usdc.address,
+      weth.address,
+      usdc.address,
       -6,
       25,
       -5,
-      'USDC',
       expiry,
       windowSize,
+      _name,
+      _symbol,
       {from: creatorAddress}
     );
 

--- a/test/series/oausdt.test.ts
+++ b/test/series/oausdt.test.ts
@@ -86,12 +86,14 @@ contract('OptionsContract: Aave insurance', accounts => {
 
   describe('New option parameter test', () => {
     it('should have basic setting', async () => {
-      await oaUSDT.setDetails(_name, _symbol, {
-        from: creatorAddress
-      });
-
       assert.equal(await oaUSDT.name(), String(_name), 'set name error');
       assert.equal(await oaUSDT.symbol(), String(_symbol), 'set symbol error');
+    });
+
+    it('should update parameters', async () => {
+      await oaUSDT.updateParameters(10, 500, 16, {
+        from: creatorAddress
+      });
     });
 
     it('should open empty vault', async () => {

--- a/test/series/oausdt.test.ts
+++ b/test/series/oausdt.test.ts
@@ -94,10 +94,6 @@ contract('OptionsContract: Aave insurance', accounts => {
       assert.equal(await oaUSDT.symbol(), String(_symbol), 'set symbol error');
     });
 
-    it('should update parameters', async () => {
-      // await oaUSDT.updateParameters('100', '500', 0, 16, {from: creatorAddress});
-    });
-
     it('should open empty vault', async () => {
       await oaUSDT.openVault({
         from: creatorAddress

--- a/test/series/oausdt.test.ts
+++ b/test/series/oausdt.test.ts
@@ -1,7 +1,7 @@
 import {
   OptionsFactoryInstance,
   OTokenInstance,
-  Erc20MintableInstance,
+  MockErc20Instance,
   MockOracleInstance
 } from '../../build/types/truffle-types';
 
@@ -16,9 +16,10 @@ const {
 const OTokenContract = artifacts.require('oToken');
 const OptionsFactory = artifacts.require('OptionsFactory');
 const MockOracle = artifacts.require('MockOracle');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 
 import Reverter from '../utils/reverter';
+import {ZERO_ADDRESS} from '../utils/helper';
 
 contract('OptionsContract: Aave insurance', accounts => {
   const reverter = new Reverter(web3);
@@ -30,8 +31,8 @@ contract('OptionsContract: Aave insurance', accounts => {
   let optionsFactory: OptionsFactoryInstance;
   let oaUSDT: OTokenInstance;
   let oracle: MockOracleInstance;
-  let ausdt: Erc20MintableInstance;
-  let usdt: Erc20MintableInstance;
+  let ausdt: MockErc20Instance;
+  let usdt: MockErc20Instance;
 
   const _name = 'Aave USDT insurance';
   const _symbol = 'oaUSDT';
@@ -47,32 +48,33 @@ contract('OptionsContract: Aave insurance', accounts => {
     // oracle = MockOracle.at()
 
     // 1.2 Mock aUSDT contract
-    ausdt = await MintableToken.new();
+    ausdt = await MockERC20.new('Aave USDC', 'aUSDC', 6);
     await ausdt.mint(creatorAddress, '1000000000'); // 1000 ausdt
     await ausdt.mint(firstOwner, '1000000000');
     await ausdt.mint(tokenHolder, '1000000000');
 
     // 1.3 Mock USDT contract
-    usdt = await MintableToken.new();
+    usdt = await MockERC20.new('USDT', 'USDT', 6);
 
     // 2. Deploy the Options Factory contract and add assets to it
     optionsFactory = await OptionsFactory.deployed();
 
-    await optionsFactory.updateAsset('aUSDT', ausdt.address);
-    await optionsFactory.updateAsset('USDT', usdt.address);
+    await optionsFactory.whitelistAsset(ZERO_ADDRESS);
+    await optionsFactory.whitelistAsset(ausdt.address);
+    await optionsFactory.whitelistAsset(usdt.address);
 
     // Create the unexpired options contract
     const optionsContractResult = await optionsFactory.createOptionsContract(
-      'ETH',
-      -18,
-      'aUSDT',
-      -6,
+      ZERO_ADDRESS,
+      ausdt.address,
+      usdt.address,
       -6,
       950,
       -9,
-      'USDT',
       expiry,
       windowSize,
+      _name,
+      _symbol,
       {from: creatorAddress}
     );
 

--- a/test/series/oyDai.test.ts
+++ b/test/series/oyDai.test.ts
@@ -1,6 +1,6 @@
 // import {expect} from 'chai';
 // import {
-//   Erc20MintableInstance,
+//   MockErc20Instance,
 //   OTokenInstance,
 //   OptionsFactoryInstance,
 //   OptionsExchangeInstance,
@@ -13,7 +13,7 @@
 // import {Address} from 'cluster';
 
 // const OptionsFactory = artifacts.require('OptionsFactory');
-// const MintableToken = artifacts.require('ERC20Mintable');
+// const MockERC20 = artifacts.require('MockERC20');
 // const UniswapFactory = artifacts.require('UniswapFactoryInterface');
 // const UniswapExchange = artifacts.require('UniswapExchangeInterface');
 // const OptionsExchange = artifacts.require('OptionsExchange.sol');
@@ -57,7 +57,7 @@
 
 //   const optionsContracts: OTokenInstance[] = [];
 //   let optionsFactory: OptionsFactoryInstance;
-//   let yDai: Erc20MintableInstance;
+//   let yDai: MockErc20Instance;
 //   let uniswapFactory: UniswapFactoryInterfaceInstance;
 //   let optionsExchange: OptionsExchangeInstance;
 //   let oracle: OracleInstance;
@@ -82,7 +82,7 @@
 //     if (!contractsDeployed) {
 //       oracle = await Oracle.at(oracleAddress);
 //       // 1.2 Mock Dai contract
-//       yDai = await MintableToken.at(yDaiAddress);
+//       yDai = await MockERC20.at(yDaiAddress);
 
 //       // 2. Deploy our contracts
 //       // Deploy the Options Exchange

--- a/test/series/weth-put.test.ts
+++ b/test/series/weth-put.test.ts
@@ -9,7 +9,7 @@ const {time, expectRevert, expectEvent} = require('@openzeppelin/test-helpers');
 
 const OTokenContract = artifacts.require('oToken');
 const OptionsFactory = artifacts.require('OptionsFactory');
-const MintableToken = artifacts.require('ERC20Mintable');
+const MockERC20 = artifacts.require('MockERC20');
 
 import Reverter from '../utils/reverter';
 
@@ -39,33 +39,33 @@ contract('OptionsContract: weth put', accounts => {
 
     // 1. Deploy mock contracts
     // 1.2 Mock weth contract
-    weth = await MintableToken.new();
+    weth = await MockERC20.new('weth', 'weth', 18);
     await weth.mint(creatorAddress, wethAmount); // 1000 weth
     await weth.mint(tokenHolder, wethAmount);
 
     // 1.3 Mock USDC contract
-    usdc = await MintableToken.new();
+    usdc = await MockERC20.new('USDC', 'USDC', 6);
     await usdc.mint(creatorAddress, usdcAmount);
     await usdc.mint(firstOwner, usdcAmount);
 
     // 2. Deploy the Options Factory contract and add assets to it
     optionsFactory = await OptionsFactory.deployed();
 
-    await optionsFactory.addAsset('WETH', weth.address);
-    await optionsFactory.addAsset('USDC', usdc.address);
+    await optionsFactory.whitelistAsset(weth.address);
+    await optionsFactory.whitelistAsset(usdc.address);
 
     // Create the unexpired options contract
     const optionsContractResult = await optionsFactory.createOptionsContract(
-      'USDC',
-      -6,
-      'WETH',
-      -18,
+      usdc.address,
+      weth.address,
+      usdc.address,
       -6,
       25,
       -5,
-      'USDC',
       expiry,
       windowSize,
+      _name,
+      _symbol,
       {from: creatorAddress}
     );
 
@@ -83,10 +83,6 @@ contract('OptionsContract: weth put', accounts => {
 
       assert.equal(await oWeth.name(), String(_name), 'set name error');
       assert.equal(await oWeth.symbol(), String(_symbol), 'set symbol error');
-    });
-
-    it('should update parameters', async () => {
-      await oWeth.updateParameters('100', '500', 0, 10, {from: creatorAddress});
     });
 
     it('should open empty vault', async () => {

--- a/test/testnetDeploy.test.ts
+++ b/test/testnetDeploy.test.ts
@@ -1,6 +1,6 @@
 // import {expect} from 'chai';
 // import {
-//   Erc20MintableInstance,
+//   MockErc20Instance,
 //   OTokenInstance,
 //   OptionsFactoryInstance,
 //   OptionsExchangeInstance,
@@ -13,7 +13,7 @@
 // import {Address} from 'cluster';
 
 // const OptionsFactory = artifacts.require('OptionsFactory');
-// const MintableToken = artifacts.require('ERC20Mintable');
+// const MockERC20 = artifacts.require('MockERC20');
 // const UniswapFactory = artifacts.require('UniswapFactoryInterface');
 // const UniswapExchange = artifacts.require('UniswapExchangeInterface');
 // const OptionsExchange = artifacts.require('OptionsExchange.sol');
@@ -59,8 +59,8 @@
 
 //   const optionsContracts: OTokenInstance[] = [];
 //   let optionsFactory: OptionsFactoryInstance;
-//   let dai: Erc20MintableInstance;
-//   let usdc: Erc20MintableInstance;
+//   let dai: MockErc20Instance;
+//   let usdc: MockErc20Instance;
 //   let uniswapFactory: UniswapFactoryInterfaceInstance;
 //   let optionsExchange: OptionsExchangeInstance;
 //   let oracle: OracleInstance;
@@ -118,9 +118,9 @@
 //     if (!contractsDeployed) {
 //       oracle = await Oracle.deployed();
 //       // 1.2 Mock Dai contract
-//       dai = await MintableToken.at(daiAddress);
+//       dai = await MockERC20.at(daiAddress);
 //       // 1.3 USDC contract
-//       usdc = await MintableToken.at(usdcAddress);
+//       usdc = await MockERC20.at(usdcAddress);
 
 //       // 2. Deploy our contracts
 //       // Deploy the Options Exchange
@@ -434,7 +434,7 @@
 
 //     xit('should be able to buy oTokens with ERC20s', async () => {
 //       const paymentTokenAddr = '0x2448eE2641d78CC42D7AD76498917359D961A783';
-//       const paymentToken = await MintableToken.at(paymentTokenAddr);
+//       const paymentToken = await MockERC20.at(paymentTokenAddr);
 //       // set to optionsCotnracs[0].address
 //       const oTokenAddress = optionsContractAddresses[0];
 //       await paymentToken.approve(

--- a/test/utils/helper.ts
+++ b/test/utils/helper.ts
@@ -18,3 +18,5 @@ export function calculateMaxOptionsToCreate(
       (minCollateralizationRatio * strikePrice)
   );
 }
+
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';


### PR DESCRIPTION
## Description
Remove unnecessary parameters (`collateralExp` and `underlyingExp`) in `Otoken`, `OptionsProtocol` constructor, so we can set parameters and name within 1 transaction. 

## Updates
### In Factory: 
* To avoid stack too deep error, we have to remove the usage of an additional `tokens(string => addresss) ` mapping.  I removed the tokens mapping and let the `createOptionsContract` function take in address directly as parameter. 
* The whiteliste functionality is changed into a simple mapping: `whitelisted[asset] => bool`. The admin can set an asset to whitelisted, then people can create option with this asset.

### Otoken:
* Remove `collateralExp` and `underlyingExp` from the constructor, change the param order of the constructor.
### OptionsContract:
* Remove `collateralExp` and `underlyingExp` from the constructor, change the param order of the constructor.
* Remove `transactionFee` variables
* Set default min collateral ratio to 100% (so we don't have to update it everytime)

### Tests
* Now we read token exp from `ERCDetailed().decimals()`, so all address passed in as testing token need to have `decimals()` interface otherwise the constructor will revert. This decimals function didn't exist on the old `ERC20Mintable` mock. So I change all the `ERC20Mintable` to `MockERC20`, which can specify name, symbol and decimals.