### PR TITLE
[H01] Check for ETH deposited in buyOTokens.

### DIFF
--- a/contracts/OptionsExchange.sol
+++ b/contracts/OptionsExchange.sol
@@ -255,7 +255,7 @@ contract OptionsExchange {
                 msg.sender.transfer(msg.value.sub(ethToTransfer));
             } else if (msg.value > 0) {
                 ethToTransfer = msg.value;
-                amount = exchange.getTokenToEthOutputPrice(msg.value);
+                amount = exchange.getTokenToEthOutputPrice(ethToTransfer);
             }
 
             emit BuyOTokens(

--- a/contracts/OptionsExchange.sol
+++ b/contracts/OptionsExchange.sol
@@ -7,6 +7,8 @@ import "./packages/IERC20.sol";
 
 
 contract OptionsExchange {
+    using SafeMath for uint256;
+
     uint256 internal constant LARGE_BLOCK_SIZE = 1651753129000;
     uint256 internal constant LARGE_APPROVAL_NUMBER = 10**30;
 
@@ -250,7 +252,7 @@ contract OptionsExchange {
                     "Options Exchange: Insufficient ETH"
                 );
                 // send excess value back to user
-                msg.sender.transfer(msg.value - ethToTransfer);
+                msg.sender.transfer(msg.value.sub(ethToTransfer));
             } else if (msg.value > 0) {
                 ethToTransfer = msg.value;
                 amount = exchange.getTokenToEthOutputPrice(msg.value);

--- a/contracts/OptionsExchange.sol
+++ b/contracts/OptionsExchange.sol
@@ -245,15 +245,16 @@ contract OptionsExchange {
             uint256 amount = _amt;
             if (_amt > 0) {
                 ethToTransfer = exchange.getEthToTokenOutputPrice(_amt);
+                require(
+                    msg.value >= ethToTransfer,
+                    "Options Exchange: Insufficient ETH"
+                );
+                // send excess value back to user
+                msg.sender.transfer(msg.value - ethToTransfer);
             } else if (msg.value > 0) {
                 ethToTransfer = msg.value;
                 amount = exchange.getTokenToEthOutputPrice(msg.value);
             }
-
-            require(
-                msg.value >= ethToTransfer,
-                "Options Exchange: Insufficient ETH"
-            );
 
             emit BuyOTokens(
                 msg.sender,


### PR DESCRIPTION
Added a check to make sure msg.value is sufficient to purchase the amount specified.
Also added functionality to set amount = 0 and spend all of msg.value.
This is in response to openZeppelin: 
"Additionally, consider implementing a way to either return any ETH deposited in excess, or trade all ETH sent for oTokens."
